### PR TITLE
(PA) Added delegate to allow for when the user has cancalled the login flow

### DIFF
--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/Login/SFLoginViewController.m
@@ -358,7 +358,7 @@
         self.previousUserAccount = fromUser;
 }
 
-
+- (void)didStopLoginFlow;
 
 
 @end

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.h
@@ -213,6 +213,11 @@ NS_SWIFT_NAME(UserAccountManagerDelegate)
          didSwitchFromUser:(SFUserAccount *)previousUserAccount
                     toUser:(nullable SFUserAccount *)currentUserAccount NS_SWIFT_NAME(userAccountManager(accountManager:didSwitchFrom:to:));
 
+/**
+ * Called when login flow has been cancelled by the user.
+ */
+- (void)didStopLoginFlow;
+
 @end
 
 NS_SWIFT_NAME(UserAccountPersister)

--- a/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
+++ b/libs/SalesforceSDKCore/SalesforceSDKCore/Classes/UserAccount/SFUserAccountManager.m
@@ -407,6 +407,10 @@ static NSString * const kSFGenericFailureAuthErrorHandler = @"GenericFailureErro
             completionBlock(result);
         }];
     }
+    
+    [self enumerateDelegates:^(id <SFUserAccountManagerDelegate> delegate) {
+        [delegate didStopLoginFlow];
+    }];
   
 }
 


### PR DESCRIPTION
@noel-adapptor - I've add this delegate func so that we can tell when the user has dismissed the login web view controller and dismiss any loading views that we've shown when the user has launched the login flow.